### PR TITLE
Add per-interval latency reporting via live Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,45 @@ usage: benchbase
     --dialects-export <arg>     Export benchmark SQL to a dialects file
     --execute <arg>             Execute the benchmark workload
  -h,--help                      Print this help
- -im,--interval-monitor <arg>   Throughput Monitoring Interval in
-                                milliseconds
+ -im,--interval-monitor <arg>   Monitoring interval in milliseconds. Enables
+                                the live monitor thread; see -mt for type.
  -jh,--json-histograms <arg>    Export histograms to JSON file
     --load <arg>                Load data using the benchmark's data
                                 loader
+ -mt,--monitor-type <arg>       Type of live monitoring: throughput (default),
+                                advanced, or latency. 'latency' logs per-
+                                interval latency percentiles (p50/p95/p99) in
+                                addition to throughput and appends a row
+                                every -im ms to
+                                <dir>/<bench>_<timestamp>.latency-intervals.csv.
+                                'advanced' does the same plus DB-specific
+                                metrics where supported.
  -s,--sample <arg>              Sampling window
 ```
+
+#### Live Latency Reporting
+
+Use `-im` together with `-mt latency` to stream per-interval latency statistics
+while the benchmark runs. For example, emit stats every second during a TPC-C
+run on Postgres:
+
+```sh
+java -jar benchbase.jar \
+  -b tpcc -c config/postgres/sample_tpcc_config.xml \
+  --create=true --load=true --execute=true \
+  -im 1000 -mt latency -d results/tpcc-live
+```
+
+The monitor logs a line per interval:
+
+```text
+INFO  Monitor - Latency [window=1000ms] count=1523 tps=1523.00 p50=4312us p95=9871us p99=15240us min=812us max=42100us avg=5120.4
+```
+
+And appends rows to `results/tpcc-live/tpcc_<timestamp>.latency-intervals.csv`
+with columns
+`elapsed_sec,interval_ms,count,tps,min_us,p25_us,p50_us,p75_us,p90_us,p95_us,p99_us,max_us,avg_us,stdev_us`,
+suitable for feeding into plotting tools.
 
 ### How to Run with Maven
 

--- a/src/main/java/com/oltpbenchmark/DBWorkload.java
+++ b/src/main/java/com/oltpbenchmark/DBWorkload.java
@@ -99,6 +99,7 @@ public class DBWorkload {
     class SimpleMonitorInfo implements MonitorInfo {
       private int interval = 0;
       private MonitorInfo.MonitoringType type = MonitorInfo.MonitoringType.THROUGHPUT;
+      private java.util.Optional<java.nio.file.Path> latencyCsvPath = java.util.Optional.empty();
 
       @Override
       public int getMonitoringInterval() {
@@ -110,6 +111,11 @@ public class DBWorkload {
         return type;
       }
 
+      @Override
+      public java.util.Optional<java.nio.file.Path> getLatencyReportCsvPath() {
+        return latencyCsvPath;
+      }
+
       // Custom setters
       public void updateInterval(int val) {
         this.interval = val;
@@ -117,6 +123,10 @@ public class DBWorkload {
 
       public void updateType(MonitoringType val) {
         this.type = val;
+      }
+
+      public void updateLatencyCsvPath(java.nio.file.Path p) {
+        this.latencyCsvPath = java.util.Optional.ofNullable(p);
       }
     }
 
@@ -134,11 +144,36 @@ public class DBWorkload {
         case "throughput":
           monitorInfoImpl.updateType(MonitorInfo.MonitoringType.THROUGHPUT);
           break;
+        case "latency":
+          monitorInfoImpl.updateType(MonitorInfo.MonitoringType.LATENCY);
+          break;
         default:
           throw new ParseException(
               "Monitoring type '"
                   + argsLine.getOptionValue("mt")
-                  + "' is undefined, allowed values are: advanced/throughput");
+                  + "' is undefined, allowed values are: advanced/throughput/latency");
+      }
+    }
+
+    // When latency reporting is requested, derive a CSV path for per-interval metrics from -d.
+    if (monitorInfoImpl.getMonitoringType() == MonitorInfo.MonitoringType.LATENCY
+        || monitorInfoImpl.getMonitoringType() == MonitorInfo.MonitoringType.ADVANCED) {
+      if (monitorInfoImpl.getMonitoringInterval() > 0) {
+        String baseDir = argsLine.getOptionValue("d", "results");
+        String bench = argsLine.getOptionValue("b", "benchmark");
+        String name =
+            org.apache.commons.lang3.StringUtils.join(
+                org.apache.commons.lang3.StringUtils.split(bench, ','), '-');
+        String fileName =
+            name + "_" + com.oltpbenchmark.util.TimeUtil.getCurrentTimeString()
+                + ".latency-intervals.csv";
+        java.nio.file.Path csvPath = java.nio.file.Paths.get(baseDir, fileName);
+        monitorInfoImpl.updateLatencyCsvPath(csvPath);
+        LOG.info("Per-interval latency metrics will be written to {}", csvPath.toAbsolutePath());
+      } else {
+        LOG.warn(
+            "Latency monitoring requested (-mt {}) but no interval was set via -im/--interval-monitor; no live reports will be emitted.",
+            monitorInfoImpl.getMonitoringType());
       }
     }
 
@@ -741,7 +776,14 @@ public class DBWorkload {
     options.addOption("h", "help", false, "Print this help");
     options.addOption("s", "sample", true, "Sampling window");
     options.addOption("im", "interval-monitor", true, "Monitoring Interval in milliseconds");
-    options.addOption("mt", "monitor-type", true, "Type of Monitoring (throughput/advanced)");
+    options.addOption(
+        "mt",
+        "monitor-type",
+        true,
+        "Type of Monitoring (throughput/advanced/latency). "
+            + "'latency' emits per-interval latency percentiles to the log and to "
+            + "<dir>/<bench>_<timestamp>.latency-intervals.csv. "
+            + "'advanced' does the same plus DB-specific metrics where supported.");
     options.addOption(
         "d",
         "directory",

--- a/src/main/java/com/oltpbenchmark/api/Worker.java
+++ b/src/main/java/com/oltpbenchmark/api/Worker.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +55,11 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
   // Interval requests used by the monitor
   private final AtomicInteger intervalRequests = new AtomicInteger(0);
+
+  // Per-interval latency samples (in microseconds) used by the latency monitor.
+  // Populated on every MEASURE-phase success; drained per-tick by Monitor.
+  private final ConcurrentLinkedQueue<Integer> intervalLatenciesMicros =
+      new ConcurrentLinkedQueue<>();
 
   private final int id;
   private final T benchmark;
@@ -129,6 +135,33 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
 
   public final int getAndResetIntervalRequests() {
     return intervalRequests.getAndSet(0);
+  }
+
+  /**
+   * Drain the per-interval latency sample buffer in microseconds. Safe to call concurrently with
+   * workers recording new samples. Returned array may be empty if no samples have been recorded
+   * since the last drain.
+   */
+  public final int[] drainIntervalLatenciesMicros() {
+    // Poll in a loop rather than copying-then-clearing so that concurrent offers made during the
+    // drain are either returned now or left for the next drain (never lost).
+    int[] buf = new int[Math.max(16, intervalLatenciesMicros.size())];
+    int count = 0;
+    Integer v;
+    while ((v = intervalLatenciesMicros.poll()) != null) {
+      if (count == buf.length) {
+        int[] grown = new int[buf.length * 2];
+        System.arraycopy(buf, 0, grown, 0, count);
+        buf = grown;
+      }
+      buf[count++] = v;
+    }
+    if (count == buf.length) {
+      return buf;
+    }
+    int[] out = new int[count];
+    System.arraycopy(buf, 0, out, 0, count);
+    return out;
   }
 
   public final Iterable<LatencyRecord.Sample> getLatencyRecords() {
@@ -313,6 +346,7 @@ public abstract class Worker<T extends BenchmarkModule> implements Runnable {
             if (preState == MEASURE && postPhase.getId() == prePhase.getId()) {
               latencies.addLatency(transactionType.getId(), start, end, this.id, prePhase.getId());
               intervalRequests.incrementAndGet();
+              intervalLatenciesMicros.offer((int) ((end - start + 500) / 1000));
             }
             if (prePhase.isLatencyRun()) {
               workloadState.startColdQuery();

--- a/src/main/java/com/oltpbenchmark/api/collectors/monitoring/DatabaseMonitor.java
+++ b/src/main/java/com/oltpbenchmark/api/collectors/monitoring/DatabaseMonitor.java
@@ -257,6 +257,7 @@ public abstract class DatabaseMonitor extends Monitor {
     int interval = this.monitorInfo.getMonitoringInterval();
 
     LOG.info("Starting Monitor Interval [{}ms]", interval);
+    initLatencyReportingIfEnabled();
     // Make sure we record one event during setup.
     if (this.conn != null) {
       cleanupCache();
@@ -273,6 +274,14 @@ public abstract class DatabaseMonitor extends Monitor {
       if (this.conn != null) {
         runExtraction();
       }
+      long measuredRequests = 0;
+      synchronized (this.testState) {
+        for (Worker<?> w : this.workers) {
+          measuredRequests += w.getAndResetIntervalRequests();
+        }
+      }
+      double tps = measuredRequests / (interval / 1000d);
+      reportLatencyTick(interval, tps);
       if (ticks % FILE_FLUSH_COUNT == 0) {
         writeToCSV();
       }
@@ -297,5 +306,6 @@ public abstract class DatabaseMonitor extends Monitor {
       }
       this.conn = null;
     }
+    super.tearDown();
   }
 }

--- a/src/main/java/com/oltpbenchmark/api/collectors/monitoring/Monitor.java
+++ b/src/main/java/com/oltpbenchmark/api/collectors/monitoring/Monitor.java
@@ -1,30 +1,49 @@
 package com.oltpbenchmark.api.collectors.monitoring;
 
 import com.oltpbenchmark.BenchmarkState;
+import com.oltpbenchmark.DistributionStatistics;
 import com.oltpbenchmark.api.BenchmarkModule;
 import com.oltpbenchmark.api.Worker;
 import com.oltpbenchmark.util.MonitorInfo;
+import com.oltpbenchmark.util.MonitorInfo.MonitoringType;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Generic monitoring class that reports the throughput of the executing workers while the benchmark
- * is being executed.
+ * is being executed. When {@link MonitoringType#LATENCY} or {@link MonitoringType#ADVANCED} is
+ * configured, the monitor additionally aggregates per-interval latency samples into a {@link
+ * DistributionStatistics} and (optionally) appends a row to a CSV file.
  */
 public class Monitor extends Thread {
-  protected static final Logger LOG = LoggerFactory.getLogger(DatabaseMonitor.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(Monitor.class);
+
+  static final String LATENCY_CSV_HEADER =
+      "elapsed_sec,interval_ms,count,tps,min_us,p25_us,p50_us,p75_us,p90_us,p95_us,p99_us,max_us,avg_us,stdev_us";
 
   protected final MonitorInfo monitorInfo;
   protected final BenchmarkState testState;
   protected final List<? extends Worker<? extends BenchmarkModule>> workers;
+
+  private BufferedWriter latencyCsvWriter;
+  private long monitorStartNanos;
 
   {
     this.setDaemon(true);
   }
 
   /**
-   * @param interval How long to wait between polling in milliseconds
+   * @param monitorInfo monitoring configuration (interval, type, optional CSV path)
+   * @param testState shared benchmark state
+   * @param workers workers whose samples should be aggregated
    */
   Monitor(
       MonitorInfo monitorInfo,
@@ -39,9 +58,15 @@ public class Monitor extends Thread {
   public void run() {
     int interval = this.monitorInfo.getMonitoringInterval();
 
-    LOG.info("Starting MonitorThread Interval [{}ms]", interval);
+    LOG.info(
+        "Starting MonitorThread type={} interval=[{}ms]",
+        this.monitorInfo.getMonitoringType(),
+        interval);
+
+    initLatencyReportingIfEnabled();
+
     while (!Thread.currentThread().isInterrupted()) {
-      // Compute the last throughput
+      // Compute the last throughput.
       long measuredRequests = 0;
       synchronized (this.testState) {
         for (Worker<?> w : this.workers) {
@@ -52,6 +77,8 @@ public class Monitor extends Thread {
       double tps = (double) measuredRequests / seconds;
       LOG.info("Throughput: {} txn/sec", tps);
 
+      reportLatencyTick(interval, tps);
+
       try {
         Thread.sleep(interval);
       } catch (InterruptedException ex) {
@@ -61,8 +88,144 @@ public class Monitor extends Thread {
     }
   }
 
+  /**
+   * Open the latency CSV (if configured) and seed the monitor start time. Subclasses that override
+   * {@link #run()} can call this in their own setup so latency reporting still works.
+   */
+  protected final void initLatencyReportingIfEnabled() {
+    if (!emitsLatency()) {
+      return;
+    }
+    openLatencyCsvIfConfigured();
+    this.monitorStartNanos = System.nanoTime();
+  }
+
+  /**
+   * Emit a single per-interval latency report (log line + CSV row) when latency reporting is
+   * enabled. No-op otherwise. Subclasses that override {@link #run()} (e.g. {@link
+   * DatabaseMonitor}) can call this once per tick.
+   *
+   * @param intervalMs monitoring interval in milliseconds (used in the log line and CSV)
+   * @param tps throughput measured for the just-completed interval
+   */
+  protected final void reportLatencyTick(int intervalMs, double tps) {
+    if (!emitsLatency()) {
+      return;
+    }
+    int[] samples = drainLatencySamples();
+    DistributionStatistics stats = DistributionStatistics.computeStatistics(samples);
+    double elapsedSec = (System.nanoTime() - monitorStartNanos) / 1_000_000_000d;
+
+    LOG.info(
+        "Latency [window={}ms] count={} tps={} p50={}us p95={}us p99={}us min={}us max={}us avg={}us",
+        intervalMs,
+        stats.getCount(),
+        String.format(Locale.ROOT, "%.2f", tps),
+        (long) stats.getMedian(),
+        (long) stats.get95thPercentile(),
+        (long) stats.get99thPercentile(),
+        (long) stats.getMinimum(),
+        (long) stats.getMaximum(),
+        String.format(Locale.ROOT, "%.1f", stats.getAverage()));
+
+    writeLatencyCsvRow(elapsedSec, intervalMs, stats, tps);
+  }
+
+  /**
+   * Drain and merge per-interval latency samples from all workers.
+   *
+   * <p>Package-private so tests can exercise the aggregation logic directly.
+   */
+  int[] drainLatencySamples() {
+    int total = 0;
+    int[][] perWorker = new int[workers.size()][];
+    for (int i = 0; i < workers.size(); ++i) {
+      int[] drained = workers.get(i).drainIntervalLatenciesMicros();
+      perWorker[i] = drained;
+      total += drained.length;
+    }
+    int[] merged = new int[total];
+    int offset = 0;
+    for (int[] chunk : perWorker) {
+      System.arraycopy(chunk, 0, merged, offset, chunk.length);
+      offset += chunk.length;
+    }
+    return merged;
+  }
+
+  private boolean emitsLatency() {
+    MonitoringType t = this.monitorInfo.getMonitoringType();
+    return t == MonitoringType.LATENCY || t == MonitoringType.ADVANCED;
+  }
+
+  private void openLatencyCsvIfConfigured() {
+    Optional<Path> path = this.monitorInfo.getLatencyReportCsvPath();
+    if (path.isEmpty()) {
+      return;
+    }
+    Path csv = path.get();
+    try {
+      if (csv.getParent() != null) {
+        Files.createDirectories(csv.getParent());
+      }
+      this.latencyCsvWriter =
+          Files.newBufferedWriter(
+              csv,
+              StandardOpenOption.CREATE,
+              StandardOpenOption.TRUNCATE_EXISTING,
+              StandardOpenOption.WRITE);
+      this.latencyCsvWriter.write(LATENCY_CSV_HEADER);
+      this.latencyCsvWriter.newLine();
+      this.latencyCsvWriter.flush();
+      LOG.info("Writing per-interval latency metrics to {}", csv.toAbsolutePath());
+    } catch (IOException e) {
+      LOG.warn("Failed to open latency CSV at {}: {}", csv, e.getMessage());
+      this.latencyCsvWriter = null;
+    }
+  }
+
+  private void writeLatencyCsvRow(
+      double elapsedSec, int intervalMs, DistributionStatistics stats, double tps) {
+    if (this.latencyCsvWriter == null) {
+      return;
+    }
+    try {
+      this.latencyCsvWriter.write(
+          String.format(
+              Locale.ROOT,
+              "%.3f,%d,%d,%.3f,%d,%d,%d,%d,%d,%d,%d,%d,%.3f,%.3f",
+              elapsedSec,
+              intervalMs,
+              stats.getCount(),
+              tps,
+              (long) stats.getMinimum(),
+              (long) stats.get25thPercentile(),
+              (long) stats.getMedian(),
+              (long) stats.get75thPercentile(),
+              (long) stats.get90thPercentile(),
+              (long) stats.get95thPercentile(),
+              (long) stats.get99thPercentile(),
+              (long) stats.getMaximum(),
+              stats.getAverage(),
+              stats.getStandardDeviation()));
+      this.latencyCsvWriter.newLine();
+      this.latencyCsvWriter.flush();
+    } catch (IOException e) {
+      LOG.warn("Failed to append latency CSV row: {}", e.getMessage());
+    }
+  }
+
   /** Called at the end of the test to do any clean up that may be required. */
   public void tearDown() {
-    // nothing to do here
+    if (this.latencyCsvWriter != null) {
+      try {
+        this.latencyCsvWriter.flush();
+        this.latencyCsvWriter.close();
+      } catch (IOException e) {
+        LOG.warn("Failed to close latency CSV: {}", e.getMessage());
+      } finally {
+        this.latencyCsvWriter = null;
+      }
+    }
   }
 }

--- a/src/main/java/com/oltpbenchmark/api/collectors/monitoring/MonitorGen.java
+++ b/src/main/java/com/oltpbenchmark/api/collectors/monitoring/MonitorGen.java
@@ -29,6 +29,7 @@ public class MonitorGen {
               return new Monitor(monitorInfo, testState, workers);
           }
         }
+      case LATENCY:
       default:
         return new Monitor(monitorInfo, testState, workers);
     }

--- a/src/main/java/com/oltpbenchmark/util/MonitorInfo.java
+++ b/src/main/java/com/oltpbenchmark/util/MonitorInfo.java
@@ -15,6 +15,8 @@
 
 package com.oltpbenchmark.util;
 
+import java.nio.file.Path;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -22,7 +24,8 @@ public interface MonitorInfo {
 
   public enum MonitoringType {
     ADVANCED,
-    THROUGHPUT;
+    THROUGHPUT,
+    LATENCY;
   }
 
   /** Monitoring interval. */
@@ -35,5 +38,14 @@ public interface MonitorInfo {
   @Value.Default
   public default MonitoringType getMonitoringType() {
     return MonitoringType.THROUGHPUT;
+  }
+
+  /**
+   * Path to the CSV file where per-interval latency metrics should be appended. When empty, no CSV
+   * is written (log lines are still emitted if the monitoring type requests them).
+   */
+  @Value.Default
+  public default Optional<Path> getLatencyReportCsvPath() {
+    return Optional.empty();
   }
 }

--- a/src/test/java/com/oltpbenchmark/api/TestWorkerLatencyBuffer.java
+++ b/src/test/java/com/oltpbenchmark/api/TestWorkerLatencyBuffer.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.oltpbenchmark.api;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.oltpbenchmark.WorkloadConfiguration;
+import com.oltpbenchmark.types.TransactionStatus;
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Worker#drainIntervalLatenciesMicros()}.
+ *
+ * <p>Uses a minimal {@link MockBenchmark} so the abstract Worker can be constructed without a live
+ * database connection, and reflection to seed the private per-interval latency queue.
+ */
+public class TestWorkerLatencyBuffer {
+
+  private static final class TestWorker extends Worker<MockBenchmark> {
+    TestWorker(MockBenchmark benchmark, int id) {
+      super(benchmark, id);
+    }
+
+    @Override
+    protected TransactionStatus executeWork(Connection conn, TransactionType txnType) {
+      return TransactionStatus.SUCCESS;
+    }
+  }
+
+  private TestWorker worker;
+
+  @Before
+  public void setUp() {
+    WorkloadConfiguration workConf = new WorkloadConfiguration();
+    workConf.setBenchmarkName("mockbenchmark");
+    // Avoid opening a real JDBC connection in Worker's constructor.
+    workConf.setNewConnectionPerTxn(true);
+    MockBenchmark bench = new MockBenchmark(workConf);
+    this.worker = new TestWorker(bench, 0);
+  }
+
+  private ConcurrentLinkedQueue<Integer> bufferOf(Worker<?> w) throws Exception {
+    Field f = Worker.class.getDeclaredField("intervalLatenciesMicros");
+    f.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    ConcurrentLinkedQueue<Integer> q = (ConcurrentLinkedQueue<Integer>) f.get(w);
+    return q;
+  }
+
+  @Test
+  public void testDrainEmptyReturnsEmptyArray() {
+    int[] drained = worker.drainIntervalLatenciesMicros();
+    assertEquals(0, drained.length);
+  }
+
+  @Test
+  public void testDrainReturnsAndClearsSamples() throws Exception {
+    ConcurrentLinkedQueue<Integer> q = bufferOf(worker);
+    q.offer(100);
+    q.offer(200);
+    q.offer(50);
+
+    int[] drained = worker.drainIntervalLatenciesMicros();
+    // The drain preserves insertion order.
+    assertArrayEquals(new int[] {100, 200, 50}, drained);
+
+    // Buffer is cleared after drain.
+    int[] second = worker.drainIntervalLatenciesMicros();
+    assertEquals(0, second.length);
+  }
+
+  @Test
+  public void testDrainConcurrentPushesDoNotLoseSamples() throws Exception {
+    final ConcurrentLinkedQueue<Integer> q = bufferOf(worker);
+    final int producerSamples = 10_000;
+    final AtomicBoolean stopDraining = new AtomicBoolean(false);
+    final java.util.List<Integer> allDrained = new java.util.ArrayList<>(producerSamples);
+    final CountDownLatch producerDone = new CountDownLatch(1);
+
+    Thread producer =
+        new Thread(
+            () -> {
+              for (int i = 1; i <= producerSamples; ++i) {
+                q.offer(i);
+              }
+              producerDone.countDown();
+            });
+
+    Thread drainer =
+        new Thread(
+            () -> {
+              while (!stopDraining.get()) {
+                for (int v : worker.drainIntervalLatenciesMicros()) {
+                  allDrained.add(v);
+                }
+              }
+              // Final drain after signaled to stop.
+              for (int v : worker.drainIntervalLatenciesMicros()) {
+                allDrained.add(v);
+              }
+            });
+
+    producer.start();
+    drainer.start();
+    assertTrue(producerDone.await(5, TimeUnit.SECONDS));
+    // Give the drainer a moment to observe any trailing items, then stop it.
+    Thread.sleep(20);
+    stopDraining.set(true);
+    drainer.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertEquals(producerSamples, allDrained.size());
+    // Because a single producer pushes 1..N in order and a single drainer observes in order, the
+    // drained values should equal [1..N].
+    int[] got = allDrained.stream().mapToInt(Integer::intValue).toArray();
+    int[] expected = new int[producerSamples];
+    for (int i = 0; i < producerSamples; ++i) {
+      expected[i] = i + 1;
+    }
+    assertArrayEquals(expected, got);
+    // And no residual items.
+    assertEquals(0, worker.drainIntervalLatenciesMicros().length);
+  }
+}

--- a/src/test/java/com/oltpbenchmark/api/collectors/monitoring/TestMonitor.java
+++ b/src/test/java/com/oltpbenchmark/api/collectors/monitoring/TestMonitor.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.oltpbenchmark.api.collectors.monitoring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.oltpbenchmark.BenchmarkState;
+import com.oltpbenchmark.WorkloadConfiguration;
+import com.oltpbenchmark.api.BenchmarkModule;
+import com.oltpbenchmark.api.MockBenchmark;
+import com.oltpbenchmark.api.TransactionType;
+import com.oltpbenchmark.api.Worker;
+import com.oltpbenchmark.types.TransactionStatus;
+import com.oltpbenchmark.util.MonitorInfo;
+import com.oltpbenchmark.util.MonitorInfo.MonitoringType;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Monitor} latency reporting (CSV + aggregation logic).
+ *
+ * <p>We avoid starting the monitor thread; instead we exercise the protected hooks {@link
+ * Monitor#initLatencyReportingIfEnabled()} and {@link Monitor#reportLatencyTick(int, double)}
+ * directly and inspect the resulting CSV.
+ */
+public class TestMonitor {
+
+  private static final class SeededWorker extends Worker<MockBenchmark> {
+    SeededWorker(MockBenchmark bench, int id) {
+      super(bench, id);
+    }
+
+    @Override
+    protected TransactionStatus executeWork(Connection conn, TransactionType txnType) {
+      return TransactionStatus.SUCCESS;
+    }
+  }
+
+  private static final class TestMonitorImpl extends Monitor {
+    TestMonitorImpl(
+        MonitorInfo info,
+        BenchmarkState state,
+        List<? extends Worker<? extends BenchmarkModule>> workers) {
+      super(info, state, workers);
+    }
+
+    // Expose protected hooks to the test.
+    void initForTest() {
+      initLatencyReportingIfEnabled();
+    }
+
+    void tickForTest(int intervalMs, double tps) {
+      reportLatencyTick(intervalMs, tps);
+    }
+  }
+
+  private Path tempCsv;
+  private BenchmarkState benchmarkState;
+
+  @Before
+  public void setUp() throws IOException {
+    this.tempCsv = Files.createTempFile("bb-latency-intervals-", ".csv");
+    this.benchmarkState = new BenchmarkState(1);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (tempCsv != null) {
+      Files.deleteIfExists(tempCsv);
+    }
+  }
+
+  private static SeededWorker makeWorker() {
+    WorkloadConfiguration workConf = new WorkloadConfiguration();
+    workConf.setBenchmarkName("mockbenchmark");
+    workConf.setNewConnectionPerTxn(true);
+    return new SeededWorker(new MockBenchmark(workConf), 0);
+  }
+
+  private static void seedLatencies(Worker<?> w, int... samplesUs) throws Exception {
+    Field f = Worker.class.getDeclaredField("intervalLatenciesMicros");
+    f.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    ConcurrentLinkedQueue<Integer> q = (ConcurrentLinkedQueue<Integer>) f.get(w);
+    for (int s : samplesUs) {
+      q.offer(s);
+    }
+  }
+
+  private MonitorInfo buildInfo(MonitoringType type, int intervalMs, Path csvPath) {
+    return new MonitorInfo() {
+      @Override
+      public int getMonitoringInterval() {
+        return intervalMs;
+      }
+
+      @Override
+      public MonitoringType getMonitoringType() {
+        return type;
+      }
+
+      @Override
+      public Optional<Path> getLatencyReportCsvPath() {
+        return Optional.ofNullable(csvPath);
+      }
+    };
+  }
+
+  @Test
+  public void testDrainLatencySamplesMergesAcrossWorkers() throws Exception {
+    SeededWorker w1 = makeWorker();
+    SeededWorker w2 = makeWorker();
+    seedLatencies(w1, 100, 200);
+    seedLatencies(w2, 300);
+
+    TestMonitorImpl m =
+        new TestMonitorImpl(
+            buildInfo(MonitoringType.LATENCY, 1000, null),
+            benchmarkState,
+            Arrays.asList(w1, w2));
+
+    int[] merged = m.drainLatencySamples();
+    Arrays.sort(merged);
+    // All three samples are merged; order across workers isn't guaranteed so we sort.
+    assertEquals(3, merged.length);
+    assertEquals(100, merged[0]);
+    assertEquals(200, merged[1]);
+    assertEquals(300, merged[2]);
+
+    // Second drain returns nothing since the buffers were emptied.
+    assertEquals(0, m.drainLatencySamples().length);
+  }
+
+  @Test
+  public void testLatencyCsvHasHeaderAndRows() throws Exception {
+    SeededWorker w = makeWorker();
+
+    TestMonitorImpl m =
+        new TestMonitorImpl(
+            buildInfo(MonitoringType.LATENCY, 500, tempCsv),
+            benchmarkState,
+            java.util.Collections.singletonList(w));
+
+    m.initForTest();
+
+    // First tick: 4 samples.
+    seedLatencies(w, 1000, 2000, 3000, 4000);
+    m.tickForTest(500, 8.0d);
+
+    // Second tick: 2 samples (smaller interval).
+    seedLatencies(w, 5000, 15000);
+    m.tickForTest(500, 4.0d);
+
+    m.tearDown();
+
+    List<String> lines = Files.readAllLines(tempCsv);
+    assertEquals(
+        "Expected header + 2 data rows in CSV: " + lines, 3, lines.size());
+    assertEquals(Monitor.LATENCY_CSV_HEADER, lines.get(0));
+
+    String row1 = lines.get(1);
+    String row2 = lines.get(2);
+
+    String[] r1 = row1.split(",");
+    // Columns: elapsed_sec,interval_ms,count,tps,min,p25,p50,p75,p90,p95,p99,max,avg,stdev
+    assertEquals("row1 col count: " + row1, 14, r1.length);
+    assertEquals("500", r1[1]);
+    assertEquals("4", r1[2]);
+    // min=1000us, max=4000us for first window
+    assertEquals("1000", r1[4]);
+    assertEquals("4000", r1[11]);
+
+    String[] r2 = row2.split(",");
+    assertEquals("2", r2[2]);
+    assertEquals("5000", r2[4]);
+    assertEquals("15000", r2[11]);
+  }
+
+  @Test
+  public void testThroughputOnlyModeWritesNoCsv() throws Exception {
+    SeededWorker w = makeWorker();
+    seedLatencies(w, 1000, 2000);
+
+    TestMonitorImpl m =
+        new TestMonitorImpl(
+            buildInfo(MonitoringType.THROUGHPUT, 500, tempCsv),
+            benchmarkState,
+            java.util.Collections.singletonList(w));
+
+    m.initForTest();
+    m.tickForTest(500, 1.0d);
+    m.tearDown();
+
+    // CSV was created by setUp() but since latency reporting is off, the monitor should not have
+    // written any header or rows. The file must still be empty.
+    assertTrue(
+        "Expected temp CSV to remain empty in THROUGHPUT mode",
+        Files.size(tempCsv) == 0);
+
+    // Samples remain in the worker's buffer because latency reporting never drained them.
+    int[] stillThere = w.drainIntervalLatenciesMicros();
+    assertEquals(2, stillThere.length);
+  }
+
+  @Test
+  public void testEmptyIntervalStillEmitsRow() throws Exception {
+    SeededWorker w = makeWorker();
+
+    TestMonitorImpl m =
+        new TestMonitorImpl(
+            buildInfo(MonitoringType.LATENCY, 500, tempCsv),
+            benchmarkState,
+            java.util.Collections.singletonList(w));
+
+    m.initForTest();
+    // No samples seeded -> empty distribution. Tick should still produce a row.
+    m.tickForTest(500, 0.0d);
+    m.tearDown();
+
+    List<String> lines = Files.readAllLines(tempCsv);
+    assertEquals(2, lines.size());
+    String[] row = lines.get(1).split(",");
+    assertEquals("0", row[2]); // count == 0
+  }
+}


### PR DESCRIPTION
## Summary

Adds periodic latency reporting to BenchBase. When the live monitor runs with
`-mt latency` (or `-mt advanced`), it now aggregates per-interval latency
samples into a `DistributionStatistics`, logs percentiles every `-im` ms, and
appends a row to a CSV next to the other `results/*.csv` files. Existing
`-mt throughput` behavior (default) is unchanged.

### Usage

```sh
java -jar benchbase.jar \
  -b noop -c config/sqlite/sample_noop_config.xml \
  --create=true --load=true --execute=true \
  -im 1000 -mt latency -d results/latency-smoke
```

Each interval logs:

```text
INFO  Monitor - Latency [window=1000ms] count=1523 tps=1523.00 p50=4312us p95=9871us p99=15240us min=812us max=42100us avg=5120.4
```

And appends to `results/latency-smoke/noop_<timestamp>.latency-intervals.csv`:

```csv
elapsed_sec,interval_ms,count,tps,min_us,p25_us,p50_us,p75_us,p90_us,p95_us,p99_us,max_us,avg_us,stdev_us
1.002,1000,1523,1523.000,812,2450,4312,6100,8340,9871,15240,42100,5120.400,3412.100
```

### Implementation

- `Worker`: new `ConcurrentLinkedQueue<Integer>` of per-interval latency samples plus a lock-free `drainIntervalLatenciesMicros()` helper. The latency (in us) of every successful MEASURE-phase transaction is pushed alongside the existing `intervalRequests` increment.
- `Monitor`: new `initLatencyReportingIfEnabled()` / `reportLatencyTick(int, double)` protected hooks. The base `Monitor.run()` calls them every tick. `DatabaseMonitor` (Postgres / SQLServer) also calls them so `-mt advanced` picks up the latency CSV.
- `MonitorInfo`: added `LATENCY` enum value and `Optional<Path> getLatencyReportCsvPath()`.
- `DBWorkload`: accepts `-mt latency`, derives the CSV path from `-d` + benchmark name + timestamp, logs the path at startup. Help text updated.

## Test plan

- [x] Unit: `TestWorkerLatencyBuffer` verifies empty drain, in-order drain, and that a concurrent producer/drainer never loses samples.
- [x] Unit: `TestMonitor` verifies cross-worker merge, CSV header + data rows, that throughput-only mode is a no-op for the latency CSV, and that an empty-window still emits a row.
- [ ] CI: full Maven test matrix (existing workflow) — please re-run if flaky.
- [ ] Local smoke run against SQLite noop (`./mvnw -Dmaven.test.skip=true -P sqlite package` + 15 s run with `-im 1000 -mt latency`) — covered by CI; easy to reproduce from a Linux dev box.

## Non-goals / follow-ups

- Does NOT touch the existing `--continuous` / `--continuous-window` code path (which has separate bugs — left for a follow-up).
- Does NOT change the post-run `*.results.csv` time-bucket file format; the new CSV is a live stream written while the benchmark runs.
- Per-transaction-type breakdown can be added later by drilling the aggregation by `TransactionType` id.
